### PR TITLE
Auto equip fix, handles shields and legs fix

### DIFF
--- a/archipelago-client/AutoEquip.cpp
+++ b/archipelago-client/AutoEquip.cpp
@@ -63,7 +63,6 @@ std::optional<EquipSlot> CAutoEquip::SortItem(uint32_t dItemID) {
 			if ((dItemID >> 0x10) == 6) return std::nullopt; //Don't equip ammo
 			if ((dItemID & 0xFF000000) << 4 != 0x10000000) return EquipSlot::rightHand1;
 			else return EquipSlot::leftHand1; //Shields equip	
-			break;
 		};
 		case ItemType::protector: {
 			if (FindEquipType(dItemID, &pHelmetList[0])) return EquipSlot::head;
@@ -71,7 +70,6 @@ std::optional<EquipSlot> CAutoEquip::SortItem(uint32_t dItemID) {
 			else if (FindEquipType(dItemID, &pHandsList[0])) return EquipSlot::arms;
 			else if (FindEquipType(dItemID, &pLegsList[0])) return EquipSlot::legs;
 			else return std::nullopt;
-			break;
 		};
 		case ItemType::accessory: {
 			if ((dItemID & 0xFFFFFF00) == 0x20002700) return std::nullopt; //It's a covenant item

--- a/archipelago-client/AutoEquip.cpp
+++ b/archipelago-client/AutoEquip.cpp
@@ -62,6 +62,7 @@ std::optional<EquipSlot> CAutoEquip::SortItem(uint32_t dItemID) {
 		case ItemType::weapon: {
 			if ((dItemID >> 0x10) == 6) return std::nullopt; //Don't equip ammo
 			if ((dItemID & 0xFF000000) << 4 != 0x10000000) return EquipSlot::rightHand1;
+			else return EquipSlot::leftHand1; //Shields equip	
 			break;
 		};
 		case ItemType::protector: {

--- a/archipelago-client/GameTypes.h
+++ b/archipelago-client/GameTypes.h
@@ -6,11 +6,12 @@
 
 // Constant values used to represent different equip slots in the DS3 inventory.
 enum class EquipSlot : uint32_t {
+	leftHand1 = 0x00,
 	rightHand1 = 0x01,
 	head = 0x0C,
 	body = 0x0D,
 	arms = 0x0E,
-	legs = 0x0E,
+	legs = 0x0F,
 	ring1 = 0x11,
 	ring2 = 0x12,
 	ring3 = 0x13,


### PR DESCRIPTION
Shields carry the same itemid as weapons, the if on line 64 results in false for all shields and the case was simply breaking without returning properly. This results in crashes when being picked up locally in game, but not when being received from AP. Adding a proper else to catch it and put it in the left hand.

In addition the leg address was set to the same address as arms.

Tested picking up shields on checks that caused crashes; tested loading in every equipment in the game (sans dlc and ngp) and everything equips properly.