### PR TITLE
Improve build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To build the project:
 3. Open `archipelago-client\archipelago-client.sln` in Visual Studio.
 4. Run Build > Build.
 
-That's it! The mod will be in `x64\Debug\archipelago.yaml`. Copy that over the file of the same
+That's it! The mod will be in `x64\Debug\archipelago.dll`. Copy that over the file of the same
 name from the released version of the mod and you can test against your local build.
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ This mod works with a single dll file but we also provide a way to downpatch the
 
 ## Building Locally
 
+To prepare your environment:
+
+1. Install Visual Studio with C++ support.
+2. Install [vcpkg](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started-vs):
+   - Clone its repository (`git clone https://github.com/microsoft/vcpkg.git`).
+   - Run its bootstrap script (`bootstrap-vcpkg.bat`).
+   - Integrate it with Visual Studio (`vcpkg integrate install`).
+
 To build the project:
 
 1. Clone the repository (`git clone https://github.com/Marechal-L/Dark-Souls-III-Archipelago-client.git`).


### PR DESCRIPTION
I love the improvements you're making here! These are just some simple steps that I had to stumble through before successfully building. 

1. Instructions for vcpkg: Visual Studio comes with a vcpkg installation, but a) [it requires manually performing the integrate step anyway](https://devblogs.microsoft.com/cppblog/vcpkg-is-now-included-with-visual-studio/) and b) for this project it still failed to build. I have a copy of the build logs, but long story short, while building the first vcpkg dependency, ninja errored out because "The C compiler is not able to compile a simple test program." 🤷 Regardless, using a separate vcpkg installation is how i eventually made things work.

2. Update spdlog: the only other problem i had, spdlog had a bunch of deprecation errors for checked_array_iter. Happily that project is still active. Checking out [their latest release's commit](https://github.com/gabime/spdlog/releases/tag/v1.14.1) fixed things. Idk if there's anything I should do to rigorously test compatibility, but i spent ~30 minutes in game and all the console logging looked normal.