### PR TITLE
Update Archipelago client

### DIFF
--- a/archipelago-client/ArchipelagoInterface.cpp
+++ b/archipelago-client/ArchipelagoInterface.cpp
@@ -3,6 +3,7 @@
 
 #include "ArchipelagoInterface.h"
 #include "ItemRandomiser.h"
+#include "subprojects/apclientpp/apuuid.hpp"
 
 #ifdef __EMSCRIPTEN__
 #define DATAPACKAGE_CACHE "/settings/datapackage.json"
@@ -106,9 +107,9 @@ BOOL CArchipelago::Initialise(std::string URI) {
 		}
 
 		for (const auto& item : items) {
-			std::string itemname = ap->get_item_name(item.item);
+			std::string itemname = ap->get_item_name(item.item, ap->get_player_game(item.player));
 			std::string sender = ap->get_player_alias(item.player);
-			std::string location = ap->get_location_name(item.location);
+			std::string location = ap->get_location_name(item.location, ap->get_player_game(item.player));
 
 			//Check if we should ignore this item
 			if (item.index < Core->pLastReceivedIndex) {

--- a/archipelago-client/ArchipelagoInterface.h
+++ b/archipelago-client/ArchipelagoInterface.h
@@ -3,7 +3,7 @@
 #include "Core.h"
 #include "GameHook.h"
 #include "subprojects/apclientpp/apclient.hpp"
-#include "subprojects/apclientpp/apuuid.hpp"
+
 
 using nlohmann::json;
 


### PR DESCRIPTION
# Summary

Update the AP client to the newest version.
I wasn't enjoying seeing the warnings in the log everytime I played the game, so decided to just update it, it wasn't too hard.
Couple of function calls needed updated and an include needed moved to compile.

# Testing

* Built and ran locally with a new Dark Souls 3 randomized run.
* Connected the client to a local server and had no issues sending items.
* No testing recieving items.
* New warning in the log on connection: `Warning: your client does not support compressed websocket connections! It may stop working in the future. If you are a player, please report this to the client's developer.` Not sure if an upstream issue or not.